### PR TITLE
Add auto-eat, invis, sell handlers and gson dep

### DIFF
--- a/mod_1_21_4/build.gradle
+++ b/mod_1_21_4/build.gradle
@@ -26,6 +26,9 @@ dependencies {
 	// Fabric API. This is technically optional, but you probably want it anyway.
 	modImplementation "net.fabricmc.fabric-api:fabric-api:${project.fabric_version}"
 
+	// JSON support (Gson)
+	implementation "com.google.code.gson:gson:2.10.1"
+
 	// Uncomment the following line to enable the deprecated Fabric API modules.
 	// These are included in the Fabric API production jar in 1.17+ and above.
 	// modImplementation "net.fabricmc.fabric-api:fabric-api-deprecated:${project.fabric_version}"

--- a/mod_1_21_4/src/main/java/com/example/mod_1_21_4/AutoEatHandler.java
+++ b/mod_1_21_4/src/main/java/com/example/mod_1_21_4/AutoEatHandler.java
@@ -1,0 +1,96 @@
+package com.example.mod_1_21_4;
+
+import net.minecraft.client.MinecraftClient;
+import net.minecraft.client.network.ClientPlayerEntity;
+import net.minecraft.entity.player.HungerManager;
+import net.minecraft.item.ItemStack;
+import net.minecraft.item.Items;
+import net.minecraft.text.Text;
+
+/**
+ * Автоматичне їдання коли рівень голоду падає
+ */
+public class AutoEatHandler {
+    private static final int HUNGER_THRESHOLD = 2; // Їсти коли голод впав на 1-2 одиниці
+    private static boolean lastFoodState = false;
+
+    public static void tick(MinecraftClient client) {
+        ClientPlayerEntity player = client.player;
+        if (player == null) return;
+
+        HungerManager hungerManager = player.getHungerManager();
+        int currentHunger = hungerManager.getFoodLevel();
+
+        // Перевірити чи голод низький
+        if (currentHunger <= HUNGER_THRESHOLD && !lastFoodState) {
+            lastFoodState = true;
+            eatFood(player);
+        } else if (currentHunger > HUNGER_THRESHOLD + 2) {
+            lastFoodState = false;
+        }
+    }
+
+    private static void eatFood(ClientPlayerEntity player) {
+        ItemStack foodItem = findFoodInInventory(player);
+
+        if (foodItem == null || foodItem.isEmpty()) {
+            player.sendMessage(Text.literal("§c⚠ Auto Eat: їжа не знайдена!"), false);
+            return;
+        }
+
+        // Знайти слот їжі
+        int slotIndex = findInventorySlot(player, foodItem);
+        if (slotIndex == -1) return;
+
+        // Перемістити їжу в гарячі слоти (слоти 0-8)
+        if (slotIndex >= 9) {
+            // Поміняти з першим вільним гарячим слотом
+            swapToHotbar(player, slotIndex);
+        }
+
+        // Установити вибраний слот
+        player.getInventory().selectedSlot = Math.min(slotIndex, 8);
+
+        // Почати їсти
+        player.setCurrentHand(net.minecraft.util.Hand.MAIN_HAND);
+        player.sendMessage(Text.literal("§a🍖 Auto Eat: їм!"), true);
+    }
+
+    private static void swapToHotbar(ClientPlayerEntity player, int slotIndex) {
+        // Знайти перший вільний слот в гарячих
+        for (int i = 0; i < 9; i++) {
+            if (player.getInventory().getStack(i).isEmpty()) {
+                // Поміняти
+                ItemStack temp = player.getInventory().getStack(slotIndex);
+                player.getInventory().setStack(slotIndex, player.getInventory().getStack(i));
+                player.getInventory().setStack(i, temp);
+                return;
+            }
+        }
+    }
+
+    private static ItemStack findFoodInInventory(ClientPlayerEntity player) {
+        for (int i = 0; i < player.getInventory().size(); i++) {
+            ItemStack stack = player.getInventory().getStack(i);
+            if (isFoodItem(stack)) {
+                return stack;
+            }
+        }
+        return null;
+    }
+
+    private static boolean isFoodItem(ItemStack stack) {
+        if (stack.isEmpty()) return false;
+        return stack.getItem().isFood();
+    }
+
+    private static int findInventorySlot(ClientPlayerEntity player, ItemStack target) {
+        for (int i = 0; i < player.getInventory().size(); i++) {
+            ItemStack stack = player.getInventory().getStack(i);
+            if (!stack.isEmpty() && stack.getItem() == target.getItem()) {
+                return i;
+            }
+        }
+        return -1;
+    }
+}

--- a/mod_1_21_4/src/main/java/com/example/mod_1_21_4/AutoInvisHandler.java
+++ b/mod_1_21_4/src/main/java/com/example/mod_1_21_4/AutoInvisHandler.java
@@ -1,0 +1,82 @@
+package com.example.mod_1_21_4;
+
+import net.minecraft.client.MinecraftClient;
+import net.minecraft.client.network.ClientPlayerEntity;
+import net.minecraft.entity.effect.StatusEffect;
+import net.minecraft.entity.effect.StatusEffects;
+import net.minecraft.item.ItemStack;
+import net.minecraft.item.Items;
+import net.minecraft.item.PotionItem;
+import net.minecraft.potion.PotionUtil;
+import net.minecraft.potion.Potions;
+import net.minecraft.text.Text;
+
+/**
+ * Автоматичне пиття зілля невидимості за 10 секунд до кінця ефекту
+ */
+public class AutoInvisHandler {
+    private static final long INVIS_THRESHOLD_MS = 10000; // 10 секунд у мс
+    private static boolean lastInvisState = false;
+
+    public static void tick(MinecraftClient client) {
+        ClientPlayerEntity player = client.player;
+        if (player == null) return;
+
+        // Перевірити чи є ефект невидимості
+        boolean hasInvis = player.getStatusEffect(StatusEffects.INVISIBILITY) != null;
+
+        if (hasInvis) {
+            // Отримати залишок часу ефекту
+            int duration = player.getStatusEffect(StatusEffects.INVISIBILITY).getDuration();
+            long durationMs = (long) duration * 50; // Один тик = 50мс
+
+            // Якщо залишилось менше 10 секунд - пити нове зілля
+            if (durationMs <= INVIS_THRESHOLD_MS && !lastInvisState) {
+                lastInvisState = true;
+                drinkInvisibilityPotion(player);
+            }
+        } else {
+            lastInvisState = false;
+        }
+    }
+
+    private static void drinkInvisibilityPotion(ClientPlayerEntity player) {
+        ItemStack potionItem = findInvisibilityPotion(player);
+
+        if (potionItem == null || potionItem.isEmpty()) {
+            player.sendMessage(Text.literal("§c⚠ Auto Invis: зілля невидимості не знайдено!"), false);
+            return;
+        }
+
+        int slotIndex = findInventorySlot(player, potionItem);
+        if (slotIndex != -1) {
+            player.getInventory().selectedSlot = slotIndex;
+            player.setCurrentHand(net.minecraft.util.Hand.MAIN_HAND);
+            player.sendMessage(Text.literal("§6👻 Auto Invis: п'ю зілля невидимості!"), true);
+        }
+    }
+
+    private static ItemStack findInvisibilityPotion(ClientPlayerEntity player) {
+        for (int i = 0; i < player.getInventory().size(); i++) {
+            ItemStack stack = player.getInventory().getStack(i);
+            if (stack.getItem() instanceof PotionItem) {
+                // Перевірити чи це зілля невидимості
+                if (PotionUtil.getPotion(stack) == Potions.INVISIBILITY ||
+                    PotionUtil.getPotion(stack) == Potions.LONG_INVISIBILITY) {
+                    return stack;
+                }
+            }
+        }
+        return null;
+    }
+
+    private static int findInventorySlot(ClientPlayerEntity player, ItemStack target) {
+        for (int i = 0; i < player.getInventory().size(); i++) {
+            ItemStack stack = player.getInventory().getStack(i);
+            if (!stack.isEmpty() && stack.getItem() == target.getItem()) {
+                return i;
+            }
+        }
+        return -1;
+    }
+}

--- a/mod_1_21_4/src/main/java/com/example/mod_1_21_4/AutoSellHandler.java
+++ b/mod_1_21_4/src/main/java/com/example/mod_1_21_4/AutoSellHandler.java
@@ -1,0 +1,115 @@
+package com.example.mod_1_21_4;
+
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
+import net.minecraft.client.MinecraftClient;
+import net.minecraft.client.network.ClientPlayerEntity;
+import net.minecraft.item.ItemStack;
+import net.minecraft.text.Text;
+
+import java.io.File;
+import java.io.FileReader;
+import java.io.FileWriter;
+import java.nio.file.Files;
+import java.nio.file.Paths;
+import java.util.*;
+
+/**
+ * Автоматичний продаж предметів на /ah з сумами з JSON
+ */
+public class AutoSellHandler {
+    private static final String PRICES_FILE = "mods/mod_1_21_4/prices.json";
+    private static Map<String, Integer> priceCache = new HashMap<>();
+    private static final Gson GSON = new GsonBuilder().setPrettyPrinting().create();
+    private static Set<String> searchingItems = new HashSet<>(); // Предмети на пошук
+
+    static {
+        loadPrices();
+    }
+
+    public static void tick(MinecraftClient client) {
+        ClientPlayerEntity player = client.player;
+        if (player == null) return;
+
+        // Сканувати інвентар на предмети для продажу
+        for (int i = 0; i < player.getInventory().size(); i++) {
+            ItemStack stack = player.getInventory().getStack(i);
+            
+            if (!stack.isEmpty() && shouldSellItem(stack)) {
+                String itemName = stack.getName().getString();
+                
+                if (priceCache.containsKey(itemName)) {
+                    // Ми знаємо ціну - продаємо
+                    int price = priceCache.get(itemName);
+                    executeAhSell(player, itemName, price, stack.getCount());
+                } else if (!searchingItems.contains(itemName)) {
+                    // Не знаємо ціну - починаємо пошук
+                    searchingItems.add(itemName);
+                    executeAhSearch(player, itemName);
+                }
+            }
+        }
+    }
+
+    private static void executeAhSell(ClientPlayerEntity player, String itemName, int price, int count) {
+        int totalPrice = price * count;
+        String command = "/ah sell " + totalPrice;
+        player.networkHandler.sendChatCommand(command.substring(1));
+        player.sendMessage(Text.literal("§e[Auto Sell] Продаю: " + itemName + " × " + count + " за " + totalPrice), false);
+    }
+
+    private static void executeAhSearch(ClientPlayerEntity player, String itemName) {
+        String command = "/ah search " + itemName;
+        player.networkHandler.sendChatCommand(command.substring(1));
+        player.sendMessage(Text.literal("§6[Auto Sell] Шукаю ціну для: " + itemName), false);
+    }
+
+    private static boolean shouldSellItem(ItemStack stack) {
+        // Не продавати розповсюджені предмети (приклад)
+        if (stack.getItem().toString().contains("dirt") ||
+            stack.getItem().toString().contains("stone")) {
+            return false;
+        }
+        return true;
+    }
+
+    public static void recordPrice(String itemName, int price) {
+        if (!priceCache.containsKey(itemName) || priceCache.get(itemName) > price) {
+            priceCache.put(itemName, price);
+            savePrices();
+            searchingItems.remove(itemName); // Видалити з пошуку
+        }
+    }
+
+    private static void loadPrices() {
+        try {
+            File file = new File(PRICES_FILE);
+            if (file.exists()) {
+                try (FileReader reader = new FileReader(file)) {
+                    Map<String, Integer> loaded = GSON.fromJson(reader, Map.class);
+                    if (loaded != null) {
+                        for (Map.Entry<String, Object> entry : loaded.entrySet()) {
+                            if (entry.getValue() instanceof Number) {
+                                priceCache.put(entry.getKey(), ((Number) entry.getValue()).intValue());
+                            }
+                        }
+                    }
+                }
+            }
+        } catch (Exception e) {
+            e.printStackTrace();
+        }
+    }
+
+    private static void savePrices() {
+        try {
+            File file = new File(PRICES_FILE);
+            file.getParentFile().mkdirs();
+            try (FileWriter writer = new FileWriter(file)) {
+                GSON.toJson(priceCache, writer);
+            }
+        } catch (Exception e) {
+            e.printStackTrace();
+        }
+    }
+}

--- a/mod_1_21_4/src/main/java/com/example/mod_1_21_4/Mod_1_21_4Client.java
+++ b/mod_1_21_4/src/main/java/com/example/mod_1_21_4/Mod_1_21_4Client.java
@@ -70,6 +70,18 @@ public class Mod_1_21_4Client implements ClientModInitializer {
                 if (ancientBotEnabled && client.player != null) {
                     AncientBotHandler.tick(client);
                 }
+                // Виконуємо Auto Eat tick
+                if (autoEatEnabled && client.player != null) {
+                    AutoEatHandler.tick(client);
+                }
+                // Виконуємо Auto Invis tick
+                if (autoInvisEnabled && client.player != null) {
+                    AutoInvisHandler.tick(client);
+                }
+                // Виконуємо Auto Sell tick
+                if (autoSellEnabled && client.player != null) {
+                    AutoSellHandler.tick(client);
+                }
             }
         });
 


### PR DESCRIPTION
Introduce three new gameplay handlers: AutoEatHandler (auto-consumes food at low hunger), AutoInvisHandler (auto-drinks invisibility potions near expiry) and AutoSellHandler (scans inventory, queries prices via /ah search, and sells using cached prices stored in mods/mod_1_21_4/prices.json). Add Gson (com.google.code.gson:gson:2.10.1) to build.gradle to support JSON price persistence and update Mod_1_21_4Client to call the new handlers each tick. Also includes minor formatting/structural updates to build.gradle.